### PR TITLE
feat: add admin collection permissions management API

### DIFF
--- a/app/src/app.ts
+++ b/app/src/app.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import crudRoutes from "./routes/crudRoutes";
 import authRoutes from "./routes/authRoutes";
+import collectionPermissionsRoutes from "./routes/collectionPermissionsRoutes";
 import { Request, Response, NextFunction } from "express";
 import {
   errorHandler,
@@ -18,6 +19,7 @@ app.get("/health", (req: Request, res: Response) => {
 // Routes
 app.use("/api", crudRoutes);
 app.use("/auth", authRoutes);
+app.use("/permissions", collectionPermissionsRoutes);
 
 app.use(notFoundHandler); // 404 handler for invalid routes
 app.use(errorHandler); // global error handler

--- a/app/src/controllers/collectionsPermissions.ts
+++ b/app/src/controllers/collectionsPermissions.ts
@@ -1,0 +1,58 @@
+import { Request, Response, NextFunction } from "express";
+import { AuthenticatedRequest } from "../middleware/rbac/roleAuth";
+import { createError } from "../middleware/errorHandlingAndValidation/errorHandler";
+import { CollectionsManager, collectionsManager } from "../models/collections";
+
+export const getCollectionPermissions = async (
+  req: AuthenticatedRequest,
+  res: Response,
+  next: NextFunction,
+) => {
+  try {
+    const collectionName = req.params.collectionName;
+
+    const permissions = await collectionsManager.getCollectionPermissions(collectionName);
+
+    res.json({
+      success: true,
+      data: {
+        collectionName,
+        permissions,
+      },
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const updateCollectionPermissions = async (
+  req: AuthenticatedRequest,
+  res: Response,
+  next: NextFunction,
+) => {
+  try {
+    const collectionName = req.params.collectionName;
+    const newPermissions = req.body.newPermissions;
+
+    const success = await collectionsManager.updateCollectionPermissions(
+      collectionName,
+      newPermissions
+    )
+
+    if (!success) throw createError.internal(
+      'Failed to update collection permissions',
+      'PERMISSION_UPDATE_FAILED'
+    );
+
+    res.json({
+      success: true,
+      message: `Permissions updated for collection ${collectionName}`,
+      data: {
+        collectionName,
+        permissions: newPermissions,
+      },
+    });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/app/src/middleware/errorHandlingAndValidation/validation/collectionPermissionValidation.ts
+++ b/app/src/middleware/errorHandlingAndValidation/validation/collectionPermissionValidation.ts
@@ -1,0 +1,89 @@
+import { Request, Response, NextFunction } from "express";
+import { createError } from "../errorHandler";
+import { USER_ROLES } from "../../../models/roleDefinitions";
+
+const COLLECTION_NAME_REGEX = /^[a-zA-Z][a-zA-Z0-9_-]*$/;
+const COLLECTION_NAME_MAX_LENGTH = 30;
+
+const isValidCollectionName = (collectionName: string): boolean => {
+  return (
+    typeof collectionName === 'string' &&
+    collectionName.length >= 1 &&
+    collectionName.length <= COLLECTION_NAME_MAX_LENGTH &&
+    COLLECTION_NAME_REGEX.test(collectionName)
+  );
+}
+
+const isValidRole = (role: string): boolean => {
+  return Object.values(USER_ROLES).includes(role as any);
+}
+
+const isValidPermissionsObject = (permissions: any): boolean => {
+  if (!permissions || typeof permissions !== 'object') return false;
+
+  const validActions = ['create', 'read', 'update', 'delete'];
+
+  for (const action of validActions) {
+    if (!Array.isArray(permissions[action])) return false; // check if each permissions CRUD action points to an array
+
+    for (const role of permissions[action]) {
+      if (!isValidRole(role)) return false; // check if the array contains only peoper roles
+    }
+  }
+
+  return true;
+};
+
+export const validateGetPermission = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void => {
+  const collectionName = req.params.collectionName;
+  if (!collectionName) throw createError.badRequest(
+    'Collection name is required',
+    'MISSING_COLLECTION'
+  );
+
+  const sanitizedCollectionName = collectionName.trim();
+  if (!isValidCollectionName(sanitizedCollectionName)) {
+    throw createError.badRequest(
+      'Invalid collection name format',
+      'INVALID_COLLECTION_NAME'
+    );
+  }
+
+  req.params.collectionName = sanitizedCollectionName;
+  next();
+};
+
+export const validateUpdatePermissions = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void => {
+  const collectionName = req.params.collectionName;
+  const newPermissions = req.body.newPermissions;
+
+  if (!collectionName) {
+    throw createError.badRequest('collectionName field is required', 'MISSING_COLLECTION');
+  }
+  if (!newPermissions) {
+    throw createError.badRequest('newPermissions field is required', 'MISSING_NEW_PERMISSIONS');
+  }
+
+  const sanitizedCollectionName = collectionName.trim();
+  if (!isValidCollectionName(sanitizedCollectionName)) {
+    throw createError.badRequest('Invalid collection name format', 'INVALID_COLLECTION_NAME');
+  }
+
+  if (!isValidPermissionsObject(newPermissions)) {
+    throw createError.badRequest(
+      'Invalid permissions object. Must include CRUD arrays with valid roles',
+      'INVALID_PERMISSIONS_OBJECT'
+    );
+  }
+
+  req.params.collectionName = sanitizedCollectionName;
+  next();
+};

--- a/app/src/middleware/rbac/roleAuth.ts
+++ b/app/src/middleware/rbac/roleAuth.ts
@@ -2,7 +2,7 @@ import { Request, Response, NextFunction } from "express";
 import jwt from 'jsonwebtoken';
 import { UserRole, USER_ROLES } from "../../models/roleDefinitions";
 import { createError } from "../errorHandlingAndValidation/errorHandler";
-import { CollectionsManager, CollectionPermissions } from "../../models/collections";
+import { CollectionsManager, CollectionPermissions, collectionsManager } from "../../models/collections";
 
 export interface AuthenticatedRequest extends Request {
   user?: {
@@ -19,8 +19,6 @@ const getCollectionName = (req: Request): string => {
 
   return String(collectionName);
 };
-
-const collectionManager = new CollectionsManager(); // singleton instance
 
 export const authenticateToken = (
   req: AuthenticatedRequest,
@@ -71,11 +69,11 @@ export const requireResourceAccess = (action: keyof CollectionPermissions) => {
       const collectionName = getCollectionName(req);
 
       // create collection if it doesn't exist MAKE SURE WE WANT THIS!!!!!!!!!!
-      if (!(await collectionManager.collectionExists(collectionName))) {
-        await collectionManager.createCollection(collectionName, user.userId);
+      if (!(await collectionsManager.collectionExists(collectionName))) {
+        await collectionsManager.createCollection(collectionName, user.userId);
       }
 
-      const hasPermission = await collectionManager.canPerformAction(
+      const hasPermission = await collectionsManager.canPerformAction(
         user.userId,
         user.role,
         collectionName,

--- a/app/src/models/collections.ts
+++ b/app/src/models/collections.ts
@@ -159,3 +159,4 @@ export class CollectionsManager {
   }
 }
 
+export const collectionsManager = new CollectionsManager(); // singleton instance

--- a/app/src/routes/collectionPermissionsRoutes.ts
+++ b/app/src/routes/collectionPermissionsRoutes.ts
@@ -1,0 +1,22 @@
+import { Router } from "express";
+import { getCollectionPermissions, updateCollectionPermissions } from "../controllers/collectionsPermissions";
+import { validateGetPermission, validateUpdatePermissions } from "../middleware/errorHandlingAndValidation/validation/collectionPermissionValidation";
+import { authenticateToken, requireAdmin } from "../middleware/rbac/roleAuth";
+
+const router = Router();
+
+router.get('/:collectionName/permissions', // get collection permissions
+  authenticateToken,
+  requireAdmin,
+  validateGetPermission,
+  getCollectionPermissions
+);
+
+router.put('/:collectionName/permissions', // update collection permissions
+  authenticateToken,
+  requireAdmin,
+  validateUpdatePermissions,
+  updateCollectionPermissions
+);
+
+export default router;


### PR DESCRIPTION
## Changes
- REST endpoints for getting/updating collection permissions
- Admin-only access with JWT authentication and role validation
- Input validation for permission structures

## API Endpoints
- `GET /permissions/:collectionName/permissions` - View current permissions
- `PUT /permissions/:collectionName/permissions` - Update permissions